### PR TITLE
fix phrasing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fixed `pipx list` output phrasing to convey that python version displayed is the one with which package was installed. 
 
 0.16.4
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -291,7 +291,7 @@ def _get_list_output(
     suffix = f" ({bold(shlex.quote(package_name + suffix))})" if suffix else ""
     output.append(
         f"  {'installed' if new_install else ''} package {bold(shlex.quote(package_name))}"
-        f" {bold(package_version)}{suffix}, {python_version}"
+        f" {bold(package_version)}{suffix}, installed using {python_version}"
     )
 
     if new_install and exposed_binary_names:


### PR DESCRIPTION
The python version displayed is the one using which package was installed. Not necessarily the current python version used to run the code.

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
